### PR TITLE
Fix: remove pull_request trigger from Telegram notification workflow

### DIFF
--- a/.github/workflows/telegram-notify.yml
+++ b/.github/workflows/telegram-notify.yml
@@ -4,10 +4,6 @@ on:
     branches:
       - main
       - develop
-  pull_request:
-    branches:
-      - main
-      - develop
 jobs:
   build:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## 🐞 Fixes
- Remove `pull_request trigger` from Telegram notification workflow